### PR TITLE
Fix GitHub Actions deploy workflows and add build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build All
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
       - run: npm ci
       - run: npx sls package --stage local
 
@@ -29,8 +31,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
       - run: npm ci
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: PATH=$PWD/node_modules/.bin:$PATH sam build
 
   go-serverless:
@@ -44,6 +50,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: golang/go.sum
       - run: |
           GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o bin/create/bootstrap ./lambdas/api/products/create
           GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o bin/get/bootstrap ./lambdas/api/products/get
@@ -62,5 +69,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: golang/go.sum
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: sam build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+name: Build All
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  js-serverless:
+    name: JS Serverless
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: js
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npx sls package --stage local
+
+  js-sam:
+    name: JS AWS SAM
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: js
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - uses: aws-actions/setup-sam@v2
+      - run: PATH=$PWD/node_modules/.bin:$PATH sam build
+
+  go-serverless:
+    name: Go Serverless
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: golang
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - run: |
+          GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o bin/create/bootstrap ./lambdas/api/products/create
+          GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o bin/get/bootstrap ./lambdas/api/products/get
+          GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o bin/list/bootstrap ./lambdas/api/products/list
+          GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o bin/update/bootstrap ./lambdas/api/products/update
+          GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o bin/delete/bootstrap ./lambdas/api/products/delete
+
+  go-sam:
+    name: Go AWS SAM
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: golang
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - uses: aws-actions/setup-sam@v2
+      - run: sam build

--- a/.github/workflows/deploy-go-sam.yml
+++ b/.github/workflows/deploy-go-sam.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Deploy SAM application
         run: |
           sam deploy \
-            --stack-name roastly-go-sam \
+            --stack-name roastly-api-go-sam \
             --capabilities CAPABILITY_IAM \
             --region us-east-1 \
             --resolve-s3 \

--- a/.github/workflows/deploy-go-sam.yml
+++ b/.github/workflows/deploy-go-sam.yml
@@ -46,5 +46,5 @@ jobs:
             --no-confirm-changeset \
             --no-fail-on-empty-changeset \
             --parameter-overrides \
-              HostedZoneId=${{ secrets.HOSTED_ZONE_ID }} \
-              CertificateArn=${{ secrets.CERTIFICATE_ARN }}
+              "HostedZoneId=${{ secrets.HOSTED_ZONE_ID }}" \
+              "CertificateArn=${{ secrets.CERTIFICATE_ARN }}"

--- a/.github/workflows/deploy-go-sam.yml
+++ b/.github/workflows/deploy-go-sam.yml
@@ -22,9 +22,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: golang/go.sum
 
       - name: Setup AWS SAM CLI
         uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-go-serverless.yml
+++ b/.github/workflows/deploy-go-serverless.yml
@@ -19,11 +19,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: golang/go.sum
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
 
       - name: Install JS dependencies
         working-directory: js

--- a/.github/workflows/deploy-js-sam.yml
+++ b/.github/workflows/deploy-js-sam.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Deploy SAM application
         run: |
           sam deploy \
-            --stack-name roastly-js-sam \
+            --stack-name roastly-api-js-sam \
             --capabilities CAPABILITY_IAM \
             --region us-east-1 \
             --resolve-s3 \

--- a/.github/workflows/deploy-js-sam.yml
+++ b/.github/workflows/deploy-js-sam.yml
@@ -37,7 +37,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Build SAM application
-        run: sam build
+        run: PATH=$PWD/node_modules/.bin:$PATH sam build
 
       - name: Deploy SAM application
         run: |
@@ -49,5 +49,5 @@ jobs:
             --no-confirm-changeset \
             --no-fail-on-empty-changeset \
             --parameter-overrides \
-              HostedZoneId=${{ secrets.HOSTED_ZONE_ID }} \
-              CertificateArn=${{ secrets.CERTIFICATE_ARN }}
+              "HostedZoneId=${{ secrets.HOSTED_ZONE_ID }}" \
+              "CertificateArn=${{ secrets.CERTIFICATE_ARN }}"

--- a/.github/workflows/deploy-js-sam.yml
+++ b/.github/workflows/deploy-js-sam.yml
@@ -22,12 +22,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
       - name: Setup AWS SAM CLI
         uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-js-serverless.yml
+++ b/.github/workflows/deploy-js-serverless.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ js-serverless-deploy:
 
 js-sam-deploy:
 	cd js && npm ci && PATH=$$PWD/node_modules/.bin:$$PATH sam build && sam deploy \
-		--stack-name roastly-js-sam \
+		--stack-name roastly-api-js-sam \
 		--capabilities CAPABILITY_IAM \
 		--region us-east-1 \
 		--resolve-s3 \
@@ -110,7 +110,7 @@ go-serverless-deploy: go-serverless-build
 
 go-sam-deploy:
 	cd golang && sam build && sam deploy \
-		--stack-name roastly-go-sam \
+		--stack-name roastly-api-go-sam \
 		--capabilities CAPABILITY_IAM \
 		--region us-east-1 \
 		--resolve-s3 \

--- a/golang/template.yml
+++ b/golang/template.yml
@@ -31,7 +31,7 @@ Resources:
     Properties:
       StageName: prod
       Domain:
-        DomainName: roastly-go-sam.projects.lauraesteves.com
+        DomainName: roastly-api-go-sam.projects.lauraesteves.com
         CertificateArn: !Ref CertificateArn
         Route53:
           HostedZoneId: !Ref HostedZoneId
@@ -39,7 +39,7 @@ Resources:
   ProductsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: roastly-go-sam-products
+      TableName: roastly-api-go-sam-products
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: id
@@ -136,4 +136,4 @@ Resources:
 Outputs:
   ApiUrl:
     Description: Custom domain URL
-    Value: https://roastly-go-sam.projects.lauraesteves.com
+    Value: https://roastly-api-go-sam.projects.lauraesteves.com

--- a/js/template.yml
+++ b/js/template.yml
@@ -28,7 +28,7 @@ Resources:
     Properties:
       StageName: prod
       Domain:
-        DomainName: roastly-js-sam.projects.lauraesteves.com
+        DomainName: roastly-api-js-sam.projects.lauraesteves.com
         CertificateArn: !Ref CertificateArn
         Route53:
           HostedZoneId: !Ref HostedZoneId
@@ -36,7 +36,7 @@ Resources:
   ProductsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: roastly-js-sam-products
+      TableName: roastly-api-js-sam-products
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: id
@@ -163,4 +163,4 @@ Resources:
 Outputs:
   ApiUrl:
     Description: Custom domain URL
-    Value: https://roastly-js-sam.projects.lauraesteves.com
+    Value: https://roastly-api-js-sam.projects.lauraesteves.com

--- a/postman/roastly-api.prod.go-awssam.postman_environment.json
+++ b/postman/roastly-api.prod.go-awssam.postman_environment.json
@@ -4,7 +4,7 @@
   "values": [
     {
       "key": "baseUrl",
-      "value": "https://roastly-go-sam.projects.lauraesteves.com",
+      "value": "https://roastly-api-go-sam.projects.lauraesteves.com",
       "enabled": true
     },
     {

--- a/postman/roastly-api.prod.js-awssam.postman_environment.json
+++ b/postman/roastly-api.prod.js-awssam.postman_environment.json
@@ -4,7 +4,7 @@
   "values": [
     {
       "key": "baseUrl",
-      "value": "https://roastly-js-sam.projects.lauraesteves.com",
+      "value": "https://roastly-api-js-sam.projects.lauraesteves.com",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Summary

- Fix JS SAM build: add `node_modules/.bin` to PATH so `sam build` finds `esbuild`
- Fix SAM deploy parameter overrides: quote values to handle empty secrets gracefully
- Rename SAM stacks from `roastly-js-sam`/`roastly-go-sam` to `roastly-api-js-sam`/`roastly-api-go-sam` to match IAM policy resource patterns
- Update table names, domain names, and Postman environment URLs to match new stack names
- Add `Build All` workflow that builds all 4 project variants (JS Serverless, JS SAM, Go Serverless, Go SAM) in parallel on every push and PR

## Test plan

- [x] `Build All` workflow passes for all 4 variants
- [x] `Deploy JS AWS SAM` workflow succeeds with renamed stack
- [x] `Deploy Go AWS SAM` workflow succeeds with renamed stack
- [x] `Deploy JS Serverless` workflow succeeds
- [x] `Deploy Go Serverless` workflow succeeds